### PR TITLE
34 naming convention for tests

### DIFF
--- a/src/main/java/org/example/CMVCalculator.java
+++ b/src/main/java/org/example/CMVCalculator.java
@@ -123,14 +123,14 @@ public class CMVCalculator {
      * (2 ≤ Q PTS ≤ NUMPOINTS), (1 ≤ QUADS ≤ 3)
      *
      * @param dataPoints 2D array of doubles, where each sub-array represents a point in the form of [x, y]
-     * @param QPTS       an integer representing the number of consecutive points to check in each set
-     * @param QUADS      an integer representing the number of quadrants that must be present in a set of QPTS points for the method to return true
-     * @return true if at least one set of consecutive QPTS points in dataPoints fall in more than QUADS quadrants, false otherwise.
+     * @param qPts       an integer representing the number of consecutive points to check in each set
+     * @param QUADS      an integer representing the number of quadrants that must be present in a set of qPts points for the method to return true
+     * @return true if at least one set of consecutive qPts points in dataPoints fall in more than QUADS quadrants, false otherwise.
      */
-    public static boolean checkLIC4(double[][] dataPoints, int QPTS, int QUADS) {
-        for (int i = 0; i <= dataPoints.length - QPTS; i++) {
+    public static boolean checkLIC4(double[][] dataPoints, int qPts, int QUADS) {
+        for (int i = 0; i <= dataPoints.length - qPts; i++) {
             int[] quadrantCount = new int[4];
-            for (int j = i; j < i + QPTS; j++) {
+            for (int j = i; j < i + qPts; j++) {
                 double x = dataPoints[j][0];
                 double y = dataPoints[j][1];
                 if (x >= 0 && y >= 0) {
@@ -222,26 +222,26 @@ public class CMVCalculator {
     }
 
     /**
-     * There exists at least one set of two data points separated by exactly K_PTS consecutive intervening points that are a distance greater than the length, LENGTH1, apart. The condition
+     * There exists at least one set of two data points separated by exactly kPts consecutive intervening points that are a distance greater than the length, LENGTH1, apart. The condition
      * is not met when NUMPOINTS < 3.
      * 1 ≤ K PTS ≤ (NUMPOINTS−2)
      *
      * @param points  a 2D array indicating the 2D point coordinates
      * @param LENGTH1 a double value given in the parameters
-     * @param K_PTS   an int value given in the parameters
-     * @return True if there is atleast one set of two points, separated by K_PTS consecutive intevening points, with a distance greater than LENGTH1. False Otherwise.
+     * @param kPts   an int value given in the parameters
+     * @return True if there is atleast one set of two points, separated by kPts consecutive intevening points, with a distance greater than LENGTH1. False Otherwise.
      */
-    public static boolean checkLIC7(double[][] points, double LENGTH1, int K_PTS) {
+    public static boolean checkLIC7(double[][] points, double LENGTH1, int kPts) {
 
         if (points.length < 3) {
             return false;
-        } else if (K_PTS < 1 || K_PTS > points.length - 2) {
+        } else if (kPts < 1 || kPts > points.length - 2) {
             return false;
         }
 
 
-        for (int i = 0; i < points.length - K_PTS - 1; i++) {
-            if (MathUtils.calcDistanceBetweenTwoPoints(points[i], points[i + K_PTS + 1]) > LENGTH1) {
+        for (int i = 0; i < points.length - kPts - 1; i++) {
+            if (MathUtils.calcDistanceBetweenTwoPoints(points[i], points[i + kPts + 1]) > LENGTH1) {
                 return true;
             }
         }
@@ -258,23 +258,23 @@ public class CMVCalculator {
      *
      * @param points  a 2D array indicating the 2D point coordinates
      * @param RADIUS1 a double value given in the parameters
-     * @param A_PTS   an int value given in the parameters
-     * @param B_PTS   an int value given in the parameters
-     * @return True, if there exist a set of three datapoints in points, separated by A_PTS and B_PTS respectivly,
+     * @param aPts   an int value given in the parameters
+     * @param bPts   an int value given in the parameters
+     * @return True, if there exist a set of three datapoints in points, separated by aPts and bPts respectivly,
      * that cannot be contained withing a circle with radius RADIUS1, False otherwise.
      */
 
-    public static boolean checkLIC8(double[][] points, double RADIUS1, int A_PTS, int B_PTS) {
-        if (A_PTS < 1 || B_PTS < 1) {
+    public static boolean checkLIC8(double[][] points, double RADIUS1, int aPts, int bPts) {
+        if (aPts < 1 || bPts < 1) {
             return false;
-        } else if (A_PTS + B_PTS > points.length - 3) {
+        } else if (aPts + bPts > points.length - 3) {
             return false;
         } else if (points.length < 5) {
             return false;
         }
 
-        for (int i = 0; i < points.length - A_PTS - B_PTS - 2; i++) {
-            double min_radius = MathUtils.calcMinimumEnclosingCircleRadius(points[i], points[i + A_PTS + 1], points[i + A_PTS + B_PTS + 2]);
+        for (int i = 0; i < points.length - aPts - bPts - 2; i++) {
+            double min_radius = MathUtils.calcMinimumEnclosingCircleRadius(points[i], points[i + aPts + 1], points[i + aPts + bPts + 2]);
             if (min_radius > RADIUS1) {
                 return true;
             }
@@ -327,19 +327,19 @@ public class CMVCalculator {
      * 1 ≤ E PTS, 1 ≤ F PTS
      * E PTS+F PTS ≤ NUMPOINTS−3
      *
-     * @param EPTS       the number of consecutive intervening points between the first and second data points
-     * @param FPTS       the number of consecutive intervening points between the second and third data points
+     * @param ePts       the number of consecutive intervening points between the first and second data points
+     * @param fPts       the number of consecutive intervening points between the second and third data points
      * @param AREA1      the area of the triangle
      * @param dataPoints the data points
      * @return true if the condition is met, false otherwise
      */
-    public static boolean checkLIC10(int EPTS, int FPTS, double AREA1, double[][] dataPoints) {
+    public static boolean checkLIC10(int ePts, int fPts, double AREA1, double[][] dataPoints) {
         if (dataPoints.length < 5) {
             return false;
         }
         for (int i = 0; i < dataPoints.length - 3; i++) {
-            for (int j = i + EPTS + 1; j < dataPoints.length - 2; j++) {
-                for (int k = j + FPTS + 1; k < dataPoints.length - 1; k++) {
+            for (int j = i + ePts + 1; j < dataPoints.length - 2; j++) {
+                for (int k = j + fPts + 1; k < dataPoints.length - 1; k++) {
                     if (MathUtils.calcTriangleArea(dataPoints[i], dataPoints[j], dataPoints[k]) > AREA1) {
                         return true;
                     }
@@ -381,7 +381,6 @@ public class CMVCalculator {
      * @param length1
      * @param length2
      * @param kPts
-     * @param NUMPOINTS
      * @return whether the points satisfy the aforementioned conditions.
      */
     public static boolean checkLIC12(double[][] points, double length1, double length2, int kPts) {
@@ -446,15 +445,15 @@ public class CMVCalculator {
      * NUMPOINTS < 5.
      * 0 ≤ AREA2
      *
-     * @param EPTS       - The number of consecutive intervening points
-     * @param FPTS       - The number of consecutive intervening points
+     * @param ePts       - The number of consecutive intervening points
+     * @param fPts       - The number of consecutive intervening points
      * @param AREA1      - The area of the triangle
      * @param AREA2      - The area of the triangle
      * @param dataPoints - The data points
      * @return true if constaints and both conditions satisfied, false otherwise
      */
 
-    public static boolean checkLIC14(double[][] dataPoints, int EPTS, int FPTS, double AREA1, double AREA2) {
+    public static boolean checkLIC14(double[][] dataPoints, int ePts, int fPts, double AREA1, double AREA2) {
 
         if (dataPoints.length < 5) {
             return false;
@@ -464,15 +463,15 @@ public class CMVCalculator {
             return false;
         }
         boolean area1requirementIsSatisfied = false;
-        for (int i = 0; i < dataPoints.length - 2 - EPTS - FPTS; i++) {
-            double area = MathUtils.calcTriangleArea(dataPoints[i], dataPoints[i + EPTS + 1], dataPoints[i + EPTS + FPTS + 2]);
+        for (int i = 0; i < dataPoints.length - 2 - ePts - fPts; i++) {
+            double area = MathUtils.calcTriangleArea(dataPoints[i], dataPoints[i + ePts + 1], dataPoints[i + ePts + fPts + 2]);
             if (area > AREA1) {
                 area1requirementIsSatisfied = true;
             }
         }
         boolean area2requirementIsSatisfied = false;
-        for (int i = 0; i < dataPoints.length - 2 - EPTS - FPTS; i++) {
-            double area = MathUtils.calcTriangleArea(dataPoints[i], dataPoints[i + EPTS + 1], dataPoints[i + EPTS + FPTS + 2]);
+        for (int i = 0; i < dataPoints.length - 2 - ePts - fPts; i++) {
+            double area = MathUtils.calcTriangleArea(dataPoints[i], dataPoints[i + ePts + 1], dataPoints[i + ePts + fPts + 2]);
             if (area < AREA2) {
                 area2requirementIsSatisfied = true;
             }

--- a/src/test/java/org/example/CMVCalculatorTest.java
+++ b/src/test/java/org/example/CMVCalculatorTest.java
@@ -125,18 +125,18 @@ public class CMVCalculatorTest {
     public void testLIC4True() {
         double[][] dataPoints = {{1, 2}, {-3, 4}, {5, -6}, {-7, -8}, {9, 10}, {-11, 12}, {13, -14}, {-15, -16}, {17, 18}, {-19, 20}};
         int QUADS = 3;
-        int QPTS = 4;
+        int qPts = 4;
         //is true because the first 4 and the next 4 elements are in their own separate quadrants which is > than QUADS
-        assertTrue(CMVCalculator.checkLIC4(dataPoints, QPTS, QUADS));
+        assertTrue(CMVCalculator.checkLIC4(dataPoints, qPts, QUADS));
     }
 
     @Test
     public void testLIC4False() {
         double[][] dataPoints = {{1, 2}, {-3, 4}, {5, -6}, {-7, -8}, {9, 10}, {-11, 12}, {13, -14}, {-15, -16}, {17, 18}, {-19, 20}};
-        int QPTS = 3;
+        int qPts = 3;
         int QUADS = 3;
-        //is false because there are 3 QPTS and 3 QUADS so can't be larger due to the condition requirement
-        assertFalse(CMVCalculator.checkLIC4(dataPoints, QPTS, QUADS));
+        //is false because there are 3 qPts and 3 QUADS so can't be larger due to the condition requirement
+        assertFalse(CMVCalculator.checkLIC4(dataPoints, qPts, QUADS));
     }
 
     @Test
@@ -269,12 +269,12 @@ public class CMVCalculatorTest {
 
         double[][] points = new double[][]{point1, point2, point3};
 
-        int C_PTS = 1;
-        int D_PTS = 1;
+        int cPts = 1;
+        int dPts = 1;
 
         double epsilon = 0.5d * Math.PI;
 
-        assertFalse(CMVCalculator.checkLIC9(points, C_PTS, D_PTS, epsilon));
+        assertFalse(CMVCalculator.checkLIC9(points, cPts, dPts, epsilon));
     }
 
     @Test
@@ -288,12 +288,12 @@ public class CMVCalculatorTest {
 
         double[][] points = new double[][]{point1, point2, point3, point4, point5, point6};
 
-        int C_PTS = 1;
-        int D_PTS = 2;
+        int cPts = 1;
+        int dPts = 2;
 
         double epsilon = 0.5d * Math.PI;
 
-        assertFalse(CMVCalculator.checkLIC9(points, C_PTS, D_PTS, epsilon));
+        assertFalse(CMVCalculator.checkLIC9(points, cPts, dPts, epsilon));
     }
 
     @Test
@@ -308,12 +308,12 @@ public class CMVCalculatorTest {
 
         double[][] points = new double[][]{point1, point2, point3, point4, point5, point6, point7};
 
-        int C_PTS = 2;
-        int D_PTS = 2;
+        int cPts = 2;
+        int dPts = 2;
 
         double epsilon = 1;
 
-        assertTrue(CMVCalculator.checkLIC9(points, C_PTS, D_PTS, epsilon));
+        assertTrue(CMVCalculator.checkLIC9(points, cPts, dPts, epsilon));
     }
 
     @Test
@@ -328,33 +328,33 @@ public class CMVCalculatorTest {
 
         double[][] points = new double[][]{point1, point2, point3, point4, point5, point6, point7};
 
-        int C_PTS = 2;
-        int D_PTS = 2;
+        int cPts = 2;
+        int dPts = 2;
 
         double epsilon = 1;
 
-        assertTrue(CMVCalculator.checkLIC9(points, C_PTS, D_PTS, epsilon));
+        assertTrue(CMVCalculator.checkLIC9(points, cPts, dPts, epsilon));
     }
 
     @Test
     public void testLIC10True() {
         double[][] dataPoints = {{0, 4}, {4, 0}, {0, 0}, {7, 8}, {9, 10}, {11, 12}, {13, 14}};
-        int EPTS = 1;
-        int FPTS = 1;
+        int ePts = 1;
+        int fPts = 1;
         double AREA1 = 0.5;
         // the points {0, 4}, {4, 0}, {0, 0} form a triangle with area greater than 0.5 (the value of AREA1).
-        // These points are separated by 1 (the value of EPTS) and 1 (the value of FPTS) consecutive intervening points, respectively
-        assertTrue(CMVCalculator.checkLIC10(EPTS, FPTS, AREA1, dataPoints));
+        // These points are separated by 1 (the value of ePts) and 1 (the value of fPts) consecutive intervening points, respectively
+        assertTrue(CMVCalculator.checkLIC10(ePts, fPts, AREA1, dataPoints));
     }
 
     @Test
     public void testLIC10False() {
         double[][] dataPoints = {{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}};
-        int EPTS = 2;
-        int FPTS = 2;
+        int ePts = 2;
+        int fPts = 2;
         double AREA1 = 0.5;
         //here the only option is (1,2), (5, 6) and (9, 10) but the points are on a straight line so the area is 0
-        assertFalse(CMVCalculator.checkLIC10(EPTS, FPTS, AREA1, dataPoints));
+        assertFalse(CMVCalculator.checkLIC10(ePts, fPts, AREA1, dataPoints));
     }
 
     @Test
@@ -362,8 +362,8 @@ public class CMVCalculatorTest {
         double[] point1 = new double[]{1.5f, 3.0f};
         double[] point2 = new double[]{1.5f, 0.0f};
         double[][] points = new double[][]{point1, point2};
-        int G_PTS = 0;
-        assertFalse(CMVCalculator.checkLIC11(points, G_PTS));
+        int gPts = 0;
+        assertFalse(CMVCalculator.checkLIC11(points, gPts));
     }
 
     @Test
@@ -372,8 +372,8 @@ public class CMVCalculatorTest {
         double[] point2 = new double[]{0.0f, 1.0f};
         double[] point3 = new double[]{1.0f, 3.0f};
         double[][] points = new double[][]{point1, point2, point3};
-        int G_PTS = 1;
-        assertFalse(CMVCalculator.checkLIC11(points, G_PTS));
+        int gPts = 1;
+        assertFalse(CMVCalculator.checkLIC11(points, gPts));
     }
 
     @Test
@@ -382,8 +382,8 @@ public class CMVCalculatorTest {
         double[] point2 = new double[]{0.0f, 1.0f};
         double[] point3 = new double[]{1.0f, 3.0f};
         double[][] points = new double[][]{point1, point2, point3};
-        int G_PTS = 1;
-        assertTrue(CMVCalculator.checkLIC11(points, G_PTS));
+        int gPts = 1;
+        assertTrue(CMVCalculator.checkLIC11(points, gPts));
 
     }
 
@@ -393,9 +393,9 @@ public class CMVCalculatorTest {
         double[] point2 = new double[]{1.5f, 0.0f};
         double length1 = 1;
         double length2 = 1;
-        int K_PTS = 0;
+        int kPts = 0;
         double[][] points = new double[][]{point1, point2};
-        assertFalse(CMVCalculator.checkLIC12(points, length1, length2, K_PTS));
+        assertFalse(CMVCalculator.checkLIC12(points, length1, length2, kPts));
     }
 
     @Test
@@ -406,9 +406,9 @@ public class CMVCalculatorTest {
         double[] point4 = new double[]{2.1f, 2.1f};
         double length1 = 1;
         double length2 = 1;
-        int K_PTS = 1;
+        int kPts = 1;
         double[][] points = new double[][]{point1, point2, point3, point4};
-        assertTrue(CMVCalculator.checkLIC12(points, length1, length2, K_PTS));
+        assertTrue(CMVCalculator.checkLIC12(points, length1, length2, kPts));
     }
 
     @Test
@@ -419,9 +419,9 @@ public class CMVCalculatorTest {
         double[] point4 = new double[]{5.1f, 5.1f};
         double length1 = 1;
         double length2 = 1;
-        int K_PTS = 1;
+        int kPts = 1;
         double[][] points = new double[][]{point1, point2, point3, point4};
-        assertFalse(CMVCalculator.checkLIC12(points, length1, length2, K_PTS));
+        assertFalse(CMVCalculator.checkLIC12(points, length1, length2, kPts));
     }
 
     @Test
@@ -432,10 +432,10 @@ public class CMVCalculatorTest {
         double[] point4 = new double[]{1.5f, 0.0f};
         double radius1 = 1;
         double radius2 = 1;
-        int A_PTS = 1;
-        int B_PTS = 1;
+        int aPts = 1;
+        int bPts = 1;
         double[][] points = new double[][]{point1, point2, point3, point4};
-        assertFalse(CMVCalculator.checkLIC13(points, A_PTS, B_PTS, radius1, radius2));
+        assertFalse(CMVCalculator.checkLIC13(points, aPts, bPts, radius1, radius2));
     }
 
     @Test
@@ -447,10 +447,10 @@ public class CMVCalculatorTest {
         double[] point5 = new double[]{4.0f, 0.0f};
         double radius1 = 1;
         double radius2 = 1;
-        int A_PTS = 1;
-        int B_PTS = 1;
+        int aPts = 1;
+        int bPts = 1;
         double[][] points = new double[][]{point1, point2, point3, point4, point5};
-        assertFalse(CMVCalculator.checkLIC13(points, A_PTS, B_PTS, radius1, radius2));
+        assertFalse(CMVCalculator.checkLIC13(points, aPts, bPts, radius1, radius2));
     }
 
     @Test
@@ -464,35 +464,35 @@ public class CMVCalculatorTest {
         double radius1 = 1;
         double radius2 = 5;
 
-        int A_PTS = 1;
-        int B_PTS = 1;
+        int aPts = 1;
+        int bPts = 1;
 
         double[][] points = new double[][]{point1, point2, point3, point4, point5};
 
-        assertTrue(CMVCalculator.checkLIC13(points, A_PTS, B_PTS, radius1, radius2));
+        assertTrue(CMVCalculator.checkLIC13(points, aPts, bPts, radius1, radius2));
     }
 
     @Test
     public void testLIC14ReturnsTrue() {
-        int E_PTS = 2;
-        int F_PTS = 1;
+        int ePts = 2;
+        int fPts = 1;
         double AREA1 = 10;
         double AREA2 = 20;
         double[][] dataPoints = new double[][]{{1, 2}, {1, 1}, {3, 1}, {22, 8}, {9, 10}, {11, 12}, {13, 14}, {15, 16}};
         //returns true because the area of the triangle formed by the first, third, and fourth data points is 16.5
 
-        assertTrue(CMVCalculator.checkLIC14(dataPoints, E_PTS, F_PTS, AREA1, AREA2));
+        assertTrue(CMVCalculator.checkLIC14(dataPoints, ePts, fPts, AREA1, AREA2));
     }
 
     @Test
     public void testLIC14ReturnsFalse() {
-        int E_PTS = 2;
-        int F_PTS = 1;
+        int ePts = 2;
+        int fPts = 1;
         double AREA1 = 30;
         double AREA2 = 40;
         double[][] dataPoints = new double[][]{{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}, {11, 12}, {13, 14}, {15, 16}};
 
         //returns false because all of these points form a line with area of 0 between any 3 of them
-        assertFalse(CMVCalculator.checkLIC14(dataPoints, E_PTS, F_PTS, AREA1, AREA2));
+        assertFalse(CMVCalculator.checkLIC14(dataPoints, ePts, fPts, AREA1, AREA2));
     }
 }


### PR DESCRIPTION
Renamed LIC test function to fit naming convention. Also rearranged the test functions so that they fit in increasing numerical order. Changed "XPTS" variable name to "xPts" format.